### PR TITLE
Fix create method test failure

### DIFF
--- a/lib/Email/ARF/Report.pm
+++ b/lib/Email/ARF/Report.pm
@@ -4,7 +4,7 @@ package Email::ARF::Report;
 # ABSTRACT: interpret Abuse Reporting Format (ARF) messages
 
 use Carp ();
-use Email::MIME 1.900 (); # ->subtypes
+use Email::MIME 1.929 (); # content-type attributes
 use Email::MIME::ContentType 1.016 (); # type/subtype
 use Scalar::Util ();
 use Params::Util qw(_INSTANCE);
@@ -188,7 +188,8 @@ sub create {
     attributes => {
       # It is so asinine that I need to do this!  Only certain blessed
       # attributes are heeded, here.  The rest are dropped. -- rjbs, 2007-03-21
-      content_type  => 'multipart/report; report-type="feedback-report"',
+      content_type  => 'multipart/report',
+      'report-type' => 'feedback-report',
     },
     parts  => [ $description_part, $report_part, $original_part ],
 

--- a/lib/Email/ARF/Report.pm
+++ b/lib/Email/ARF/Report.pm
@@ -186,8 +186,6 @@ sub create {
 
   my $report = Email::MIME->create(
     attributes => {
-      # It is so asinine that I need to do this!  Only certain blessed
-      # attributes are heeded, here.  The rest are dropped. -- rjbs, 2007-03-21
       content_type  => 'multipart/report',
       'report-type' => 'feedback-report',
     },


### PR DESCRIPTION
> Invalid Content-Type 'subtype' parameter

It seems newer versions of Email::MIME allow you to specify arbitrary arguments to the Content-Type, and with current versions of
Email::MIME::ContentType the old method of naming the attribute in the Content-Type string no longer works.